### PR TITLE
Fix: Corrected grammar in DOC!#123.doc

### DIFF
--- a/AutomationAttachments/3215/DOC!#123.doc
+++ b/AutomationAttachments/3215/DOC!#123.doc
@@ -1,1 +1,1 @@
-get file content here
+Retrive the file content here


### PR DESCRIPTION
### What I did:
Corrected the grammar in `DOC!#123.doc` by replacing:
`get file content here` → `Retrieve the file content here.`

### Why:
To improve clarity and correct the grammar as part of documentation enhancements.

### Notes:
This is my first contribution to open-source documentation. I'm currently building my skills as an aspiring API/Technical Writer.

Thanks for reviewing!